### PR TITLE
Rename APPLICATION to API_KEY in principal types on export schema

### DIFF
--- a/specs/app.kuflow.com/exports/v20230526/enums/principal-type.json
+++ b/specs/app.kuflow.com/exports/v20230526/enums/principal-type.json
@@ -1,5 +1,5 @@
 {
   "javaType": "com.kuflow.api.export.v20230526.resource.enumeration.PrincipalType",
   "type": "string",
-  "enum": ["USER", "APPLICATION", "SYSTEM"]
+  "enum": ["USER", "API_KEY", "SYSTEM"]
 }

--- a/specs/app.kuflow.com/exports/v20230526/principal.json
+++ b/specs/app.kuflow.com/exports/v20230526/principal.json
@@ -15,8 +15,8 @@
     "user": {
       "$ref": "#/definitions/principalUser"
     },
-    "application": {
-      "$ref": "#/definitions/principalApplication"
+    "apiKey": {
+      "$ref": "#/definitions/principalApiKey"
     }
   },
   "required": ["id", "type", "name"],
@@ -33,7 +33,7 @@
         }
       }
     },
-    "principalApplication": {
+    "principalApiKey": {
       "type": "object",
       "properties": {
         "id": {

--- a/specs/app.kuflow.com/exports/v20240614/enums/principal-type.json
+++ b/specs/app.kuflow.com/exports/v20240614/enums/principal-type.json
@@ -3,5 +3,5 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "javaType": "com.kuflow.server.gw.temporal.workflow.export.v20240614.resource.enumeration.PrincipalType",
   "type": "string",
-  "enum": ["USER", "APPLICATION", "SYSTEM"]
+  "enum": ["USER", "API_KEY", "SYSTEM"]
 }

--- a/specs/app.kuflow.com/exports/v20240614/principal-api-key.json
+++ b/specs/app.kuflow.com/exports/v20240614/principal-api-key.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://app.kuflow.com/exports/v20240614/principal-application.json",
+  "$id": "https://app.kuflow.com/exports/v20240614/principal-api-key.json",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {

--- a/specs/app.kuflow.com/exports/v20240614/principal.json
+++ b/specs/app.kuflow.com/exports/v20240614/principal.json
@@ -19,8 +19,8 @@
     "user": {
       "$ref": "principal-user.json"
     },
-    "application": {
-      "$ref": "principal-application.json"
+    "apiKey": {
+      "$ref": "principal-api-key.json"
     }
   },
   "required": ["$schema", "id", "type", "name"]


### PR DESCRIPTION
## Summary
- Rename `APPLICATION` to `API_KEY` in principal type enums across export schemas (v20230526 and v20240614)
- Rename `principal-application.json` to `principal-api-key.json` in v20240614
- Update all references from `PrincipalApplication` to `PrincipalApiKey`

Closes #75
