### PR TITLE
feat(process-items): refactor AI assistance to async polling model

### DIFF
--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1055,12 +1055,15 @@ paths:
 
   /process-items/{id}/task/~actions/ai-assistance:
     post:
-      summary: Trigger AI assistance for a process item task
+      summary: Trigger or poll AI assistance for a process item task
       description: |
-        Schedule an asynchronous AI assistance run for a task. The AI prompt configuration comes
-        from the task definition. The request returns immediately with the current process item
-        state. Poll `retrieveProcessItemTaskAiAssistance` to track progress and retrieve
-        completion metadata such as model and finishReason.
+        Trigger an asynchronous AI assistance run for a task and return its current state.
+
+        - If a run is already PENDING, returns its current state without starting a new one
+          (use this endpoint as the client poll).
+        - Otherwise, schedules a new run and returns the initial PENDING state.
+
+        The AI prompt configuration comes from the task definition.
       operationId: generateProcessItemTaskAiAssistance
       tags:
         - apiRestExternalV20240614ProcessItems
@@ -1068,12 +1071,12 @@ paths:
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
       responses:
-        "202":
-          description: AI assistance run accepted and scheduled.
+        "200":
+          description: Current AI assistance run status.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessItem"
+                $ref: "#/components/schemas/ProcessItemTaskAiAssistance"
         default:
           $ref: "#/components/responses/DefaultError"
 
@@ -2618,10 +2621,6 @@ components:
       properties:
         state:
           $ref: "#/components/schemas/ProcessItemTaskAiAssistanceState"
-        correlationId:
-          description: Identifier of this specific run.
-          type: string
-          format: uuid
         embeddingPending:
           description: Number of document embeddings still queued. Only present when state is PENDING.
           type: integer
@@ -2656,7 +2655,6 @@ components:
           format: date-time
       required:
         - state
-        - correlationId
         - startedAt
 
     ProcessItem:

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1029,13 +1029,15 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /process-items/{id}/task/~actions/ai-assistance:
-    post:
-      summary: Generate and apply AI assistance for a process item task
+  /process-items/{id}/task/ai-assistance:
+    get:
+      summary: Get the current AI assistance run status for a process item task
       description: |
-        Allow to generate AI assistance for a task and apply the results. The AI prompt configuration
-        comes from the task definition. The response includes the updated process item and AI metadata.
-      operationId: generateProcessItemTaskAiAssistance
+        Return the status of the latest AI assistance run for the given process item task.
+
+        Poll this endpoint after calling `generateProcessItemTaskAiAssistance` to determine when the
+        run has finished. Returns 404 when no run has ever been triggered for the task.
+      operationId: retrieveProcessItemTaskAiAssistance
       tags:
         - apiRestExternalV20240614ProcessItems
         - processItem
@@ -1043,11 +1045,35 @@ paths:
         - $ref: "#/components/parameters/IdPathParam"
       responses:
         "200":
-          description: AI assistance generated and applied to the process item task.
+          description: Current AI assistance run status.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessItemTaskAiAssistanceResponse"
+                $ref: "#/components/schemas/ProcessItemTaskAiAssistance"
+        default:
+          $ref: "#/components/responses/DefaultError"
+
+  /process-items/{id}/task/~actions/ai-assistance:
+    post:
+      summary: Trigger AI assistance for a process item task
+      description: |
+        Schedule an asynchronous AI assistance run for a task. The AI prompt configuration comes
+        from the task definition. The request returns immediately with the current process item
+        state. Poll `retrieveProcessItemTaskAiAssistance` to track progress and retrieve
+        completion metadata such as model and finishReason.
+      operationId: generateProcessItemTaskAiAssistance
+      tags:
+        - apiRestExternalV20240614ProcessItems
+        - processItem
+      parameters:
+        - $ref: "#/components/parameters/IdPathParam"
+      responses:
+        "202":
+          description: AI assistance run accepted and scheduled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessItem"
         default:
           $ref: "#/components/responses/DefaultError"
 
@@ -2578,32 +2604,60 @@ components:
           type: string
           format: email
 
-    ProcessItemTaskAiAssistanceResponse:
-      description: Response of an AI assistance action applied to a process item task.
+    ProcessItemTaskAiAssistanceState:
+      type: string
+      description: State of an AI assistance run.
+      enum:
+        - PENDING
+        - COMPLETED
+        - FAILED
+
+    ProcessItemTaskAiAssistance:
+      description: Status of the latest AI assistance run for a process item task.
       type: object
       properties:
-        processItem:
-          $ref: "#/components/schemas/ProcessItem"
+        state:
+          $ref: "#/components/schemas/ProcessItemTaskAiAssistanceState"
+        correlationId:
+          description: Identifier of this specific run.
+          type: string
+          format: uuid
+        embeddingPending:
+          description: Number of document embeddings still queued. Only present when state is PENDING.
+          type: integer
+          format: int32
+        embeddingProcessing:
+          description: Number of document embeddings actively processing. Only present when state is PENDING.
+          type: integer
+          format: int32
+        retryAfterSeconds:
+          description: Suggested number of seconds to wait before polling again. Only present when state is PENDING.
+          type: integer
+          format: int32
         model:
-          description: The AI model used for the assistance.
+          description: The AI model used for the assistance. Only present when state is COMPLETED.
           type: string
         finishReason:
-          description: The reason the AI model stopped generating.
+          description: The reason the AI model stopped generating. Only present when state is COMPLETED.
           type: string
-        promptTokens:
-          description: The number of tokens in the prompt.
-          type: integer
-          format: int32
-        completionTokens:
-          description: The number of tokens in the AI completion.
-          type: integer
-          format: int32
-        totalTokens:
-          description: The total number of tokens used.
-          type: integer
-          format: int32
+        errorCode:
+          description: Error code. Only present when state is FAILED.
+          type: string
+        errorMessage:
+          description: Human-readable error description. Only present when state is FAILED.
+          type: string
+        startedAt:
+          description: When this run was started.
+          type: string
+          format: date-time
+        finishedAt:
+          description: When this run finished (COMPLETED or FAILED). Absent while PENDING.
+          type: string
+          format: date-time
       required:
-        - processItem
+        - state
+        - correlationId
+        - startedAt
 
     ProcessItem:
       allOf:

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1055,11 +1055,19 @@ paths:
     post:
       summary: Trigger or poll AI assistance for a process item task
       description: |
-        Trigger an asynchronous AI assistance run for a task and return its current state.
+        Trigger an asynchronous AI assistance run for a task and return its current state, identified
+        by a client-supplied `requestId` (UUID). The `requestId` makes the call idempotent and lets a
+        client launch successive AI assistance attempts on the same task — one at a time.
 
-        - If a run is already PENDING, returns its current state without starting a new one
-          (use this endpoint as the client poll).
-        - Otherwise, schedules a new run and returns the initial PENDING state.
+        Behavior given the latest persisted run (if any) for the process item:
+
+        - No prior run → schedules a new run and returns the initial PENDING state (202).
+        - The stored `requestId` matches the incoming one → returns the current state of that run
+          without scheduling a new one (200). Use this to poll your own attempt.
+        - The stored `requestId` differs and the run is in a final state (COMPLETED or FAILED) →
+          schedules a new run on the same record, replacing the previous result (202).
+        - The stored `requestId` differs and the run is still PENDING → rejected with 409, since
+          another AI assistance attempt is already in progress on this task.
 
         The AI prompt configuration comes from the task definition.
       operationId: generateProcessItemTaskAiAssistance
@@ -1068,9 +1076,17 @@ paths:
         - processItem
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
+      requestBody:
+        description: Params identifying this AI assistance attempt.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessItemTaskAiAssistanceGenerateParams"
+        x-ms-requestBody-name: processItemTaskAiAssistanceGenerateParams
       responses:
         "200":
-          description: A run was already PENDING; current state returned without scheduling a new one.
+          description: The stored `requestId` matches; current state returned without scheduling a new run.
           content:
             application/json:
               schema:
@@ -2611,6 +2627,21 @@ components:
           type: string
           format: email
 
+    ProcessItemTaskAiAssistanceGenerateParams:
+      description: Params identifying a logical AI assistance attempt for a process item task.
+      type: object
+      properties:
+        requestId:
+          description: |
+            Client-supplied UUID identifying this logical AI assistance attempt. Use the same
+            `requestId` to poll an in-flight or completed run. Use a new `requestId` to start a
+            fresh run once the previous one has reached a final state. While a run is PENDING,
+            calling this endpoint with a different `requestId` is rejected with 409.
+          type: string
+          format: uuid
+      required:
+        - requestId
+
     ProcessItemTaskAiAssistanceState:
       type: string
       description: State of an AI assistance run.
@@ -2623,6 +2654,11 @@ components:
       description: Status of the latest AI assistance run for a process item task.
       type: object
       properties:
+        requestId:
+          description: |
+            Client-supplied UUID identifying the logical AI assistance attempt this run represents.
+          type: string
+          format: uuid
         state:
           $ref: "#/components/schemas/ProcessItemTaskAiAssistanceState"
         embeddingPending:
@@ -2658,6 +2694,7 @@ components:
           type: string
           format: date-time
       required:
+        - requestId
         - state
         - startedAt
 

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1029,14 +1029,14 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /process-items/{id}/task/ai-assistance:
+  /process-items/{id}/task/~actions/ai-assistance:
     get:
       summary: Get the current AI assistance run status for a process item task
       description: |
         Return the status of the latest AI assistance run for the given process item task.
 
-        Poll this endpoint after calling `generateProcessItemTaskAiAssistance` to determine when the
-        run has finished. Returns 404 when no run has ever been triggered for the task.
+        Poll this endpoint after triggering `generateProcessItemTaskAiAssistance` to determine when
+        the run has finished. Returns 404 when no run has ever been triggered for the task.
       operationId: retrieveProcessItemTaskAiAssistance
       tags:
         - apiRestExternalV20240614ProcessItems
@@ -1052,8 +1052,6 @@ paths:
                 $ref: "#/components/schemas/ProcessItemTaskAiAssistance"
         default:
           $ref: "#/components/responses/DefaultError"
-
-  /process-items/{id}/task/~actions/ai-assistance:
     post:
       summary: Trigger or poll AI assistance for a process item task
       description: |
@@ -1072,7 +1070,13 @@ paths:
         - $ref: "#/components/parameters/IdPathParam"
       responses:
         "200":
-          description: Current AI assistance run status.
+          description: A run was already PENDING; current state returned without scheduling a new one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessItemTaskAiAssistance"
+        "202":
+          description: A new run has been accepted and scheduled; initial PENDING state returned.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Rework the process item task AI assistance API from a synchronous request/response to an asynchronous trigger-and-poll pattern:

- Add GET /process-items/{id}/task/ai-assistance endpoint (retrieveProcessItemTaskAiAssistance) to poll run status
- Change POST ~actions/ai-assistance (generateProcessItemTaskAiAssistance) to return 202 Accepted with the current ProcessItem instead of blocking until completion
- Replace ProcessItemTaskAiAssistanceResponse schema with two new schemas:
  - ProcessItemTaskAiAssistanceState enum (PENDING, COMPLETED, FAILED)
  - ProcessItemTaskAiAssistance object carrying correlationId, embedding queue counters, retryAfterSeconds hint, and completion metadata (model, finishReason) depending on state

This decouples long-running AI runs from the HTTP request lifecycle, allowing clients to poll for progress and retrieve completion metadata without holding an open connection.

Close #83