### PR TITLE
feat(business-artifacts): add actions API with invoke, retrieve and create-artifact preview

### DIFF
--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1489,9 +1489,9 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/~actions/preview-create-artifact:
+  /business-artifacts/{id}/~actions/prepare-create-artifact:
     post:
-      summary: Preview the data for a CREATE_BUSINESS_ARTIFACT action
+      summary: Prepare the data for a CREATE_BUSINESS_ARTIFACT action
       description: |
         Compute the pre-filled value that a `CREATE_BUSINESS_ARTIFACT` action would produce
         for this Business Artifact, without invoking the action or persisting any state.
@@ -1499,27 +1499,27 @@ paths:
         Use it to populate a form that the user can review and edit. Once the user submits,
         the filled value is sent back via `createBusinessArtifactAction` (in the
         `createArtifact.value` field).
-      operationId: previewBusinessArtifactCreateArtifact
+      operationId: prepareBusinessArtifactCreateArtifact
       tags:
         - apiRestExternalV20240614BusinessArtifacts
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
       requestBody:
-        description: Params identifying the CREATE_BUSINESS_ARTIFACT action to preview.
+        description: Params identifying the CREATE_BUSINESS_ARTIFACT action to prepare.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BusinessArtifactCreateArtifactPreviewParams"
-        x-ms-requestBody-name: businessArtifactCreateArtifactPreviewParams
+              $ref: "#/components/schemas/BusinessArtifactCreateArtifactPrepareParams"
+        x-ms-requestBody-name: businessArtifactCreateArtifactPrepareParams
       responses:
         "200":
           description: Pre-filled value for the create-artifact form.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifactCreateArtifactPreview"
+                $ref: "#/components/schemas/BusinessArtifactCreateArtifactPrepare"
         default:
           $ref: "#/components/responses/DefaultError"
 
@@ -3070,7 +3070,7 @@ components:
       description: |
         Params for invoking an action of type CREATE_BUSINESS_ARTIFACT. The `value` is
         the (potentially user-edited) form previously obtained via the
-        `previewBusinessArtifactCreateArtifact` operation.
+        `prepareBusinessArtifactCreateArtifact` operation.
       type: object
       properties:
         value:
@@ -3078,8 +3078,8 @@ components:
           type: object
           additionalProperties: true
 
-    BusinessArtifactCreateArtifactPreviewParams:
-      description: Params identifying a CREATE_BUSINESS_ARTIFACT action to preview.
+    BusinessArtifactCreateArtifactPrepareParams:
+      description: Params identifying a CREATE_BUSINESS_ARTIFACT action to prepare.
       type: object
       properties:
         businessArtifactActionDefinitionCode:
@@ -3087,22 +3087,20 @@ components:
       required:
         - businessArtifactActionDefinitionCode
 
-    BusinessArtifactCreateArtifactPreview:
+    BusinessArtifactCreateArtifactPrepare:
       description: |
         Pre-filled value for a CREATE_BUSINESS_ARTIFACT action. Returned by the
-        preview operation; nothing is persisted on the server.
+        prepare operation; nothing is persisted on the server.
       type: object
       properties:
-        businessArtifactDefinitionId:
-          description: ID of the Business Artifact Definition that the action would create.
-          type: string
-          format: uuid
+        businessArtifactDefinitionRef:
+          $ref: "#/components/schemas/BusinessArtifactDefinitionRef"
         value:
           description: Pre-filled form value computed from the action definition.
           type: object
           additionalProperties: true
       required:
-        - businessArtifactDefinitionId
+        - businessArtifactDefinitionRef
 
     BusinessArtifactActionValueStatus:
       description: Status of a Business Artifact action value.

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1416,54 +1416,110 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/~actions/upload-user-action-document:
+  /business-artifacts/{id}/actions:
     post:
-      summary: Upload and save a document in a user action
+      summary: Invoke a Business Artifact action
       description: |
-        Allow saving a user action document uploading the content.
-      operationId: uploadBusinessArtifactUserActionDocument
+        Invoke an action on a Business Artifact.
+
+        Whether the call returns synchronously or asynchronously depends on the action type:
+
+        - `START_WORKFLOW`, `DOWNLOADABLE`: dispatched to a background worker. The
+          response returns immediately with `status=REQUESTED`. Poll
+          `retrieveBusinessArtifactAction` for the final state.
+        - `START_PROCESS`, `CREATE_BUSINESS_ARTIFACT`: completed synchronously. The
+          response returns with `status=COMPLETED` (or an error status).
+
+        If you want the method to be idempotent, please specify the `id` field in the request body.
+      operationId: createBusinessArtifactAction
       tags:
         - apiRestExternalV20240614BusinessArtifacts
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
-        - name: fileContentType
-          description: Document content type
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: fileName
-          description: Document name
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: userActionValueId
-          description: User action value ID related to de document
-          in: query
+      requestBody:
+        description: Params identifying the action to invoke.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BusinessArtifactActionCreateParams"
+        x-ms-requestBody-name: businessArtifactActionCreateParams
+      responses:
+        "200":
+          description: Business Artifact action already created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessArtifactActionValue"
+        "201":
+          description: Business Artifact action created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessArtifactActionValue"
+        default:
+          $ref: "#/components/responses/DefaultError"
+
+  /business-artifacts/{id}/actions/{actionId}:
+    get:
+      summary: Get a Business Artifact action by ID
+      description: Returns a Business Artifact action by its ID.
+      operationId: retrieveBusinessArtifactAction
+      tags:
+        - apiRestExternalV20240614BusinessArtifacts
+        - businessArtifact
+      parameters:
+        - $ref: "#/components/parameters/IdPathParam"
+        - name: actionId
+          description: The Business Artifact action ID.
+          in: path
           required: true
           schema:
             type: string
             format: uuid
-      requestBody:
-        description: Document to save.
-        required: true
-        content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-        x-ms-requestBody-name: file
+          x-ms-parameter-location: method
       responses:
         "200":
-          description: Document Saved in user action.
+          description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifact"
-        "304":
-          description: Untouched business artifact
+                $ref: "#/components/schemas/BusinessArtifactActionValue"
+        default:
+          $ref: "#/components/responses/DefaultError"
+
+  /business-artifacts/{id}/~actions/preview-create-artifact:
+    post:
+      summary: Preview the data for a CREATE_BUSINESS_ARTIFACT action
+      description: |
+        Compute the pre-filled value that a `CREATE_BUSINESS_ARTIFACT` action would produce
+        for this Business Artifact, without invoking the action or persisting any state.
+
+        Use it to populate a form that the user can review and edit. Once the user submits,
+        the filled value is sent back via `createBusinessArtifactAction` (in the
+        `createArtifact.value` field).
+      operationId: previewBusinessArtifactCreateArtifact
+      tags:
+        - apiRestExternalV20240614BusinessArtifacts
+        - businessArtifact
+      parameters:
+        - $ref: "#/components/parameters/IdPathParam"
+      requestBody:
+        description: Params identifying the CREATE_BUSINESS_ARTIFACT action to preview.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BusinessArtifactCreateArtifactPreviewParams"
+        x-ms-requestBody-name: businessArtifactCreateArtifactPreviewParams
+      responses:
+        "200":
+          description: Pre-filled value for the create-artifact form.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessArtifactCreateArtifactPreview"
         default:
           $ref: "#/components/responses/DefaultError"
 
@@ -2884,6 +2940,188 @@ components:
             - tenantId
             - businessArtifactDefinitionRef
 
+    BusinessArtifactActionValue:
+      description: |
+        A Business Artifact action invocation. The populated sub-field
+        (`startWorkflow`, `startProcess`, `downloadable`, `createArtifact`) is
+        dictated by `businessArtifactActionDefinitionRef`.
+      allOf:
+        - $ref: "#/components/schemas/AbstractAudited"
+        - type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            type:
+              $ref: "#/components/schemas/BusinessArtifactActionType"
+            status:
+              $ref: "#/components/schemas/BusinessArtifactActionValueStatus"
+            businessArtifactActionDefinitionRef:
+              $ref: "#/components/schemas/BusinessArtifactActionDefinitionRef"
+            archived:
+              type: boolean
+            startWorkflow:
+              $ref: "#/components/schemas/BusinessArtifactActionValueStartWorkflow"
+            startProcess:
+              $ref: "#/components/schemas/BusinessArtifactActionValueStartProcess"
+            downloadable:
+              $ref: "#/components/schemas/BusinessArtifactActionValueDownloadable"
+            createArtifact:
+              $ref: "#/components/schemas/BusinessArtifactActionValueCreateArtifact"
+          required:
+            - id
+            - type
+            - status
+            - businessArtifactActionDefinitionRef
+
+    BusinessArtifactActionValueStartWorkflow:
+      type: object
+      properties:
+        input:
+          $ref: "#/components/schemas/JsonValue"
+
+    BusinessArtifactActionValueStartProcess:
+      type: object
+      properties:
+        processDefinitionId:
+          type: string
+          format: uuid
+        processId:
+          type: string
+          format: uuid
+      required:
+        - processDefinitionId
+        - processId
+
+    BusinessArtifactActionValueDownloadable:
+      type: object
+      properties:
+        input:
+          $ref: "#/components/schemas/JsonValue"
+        documentUri:
+          type: string
+        documentExpired:
+          type: boolean
+
+    BusinessArtifactActionValueCreateArtifact:
+      type: object
+      properties:
+        businessArtifactDefinitionId:
+          type: string
+          format: uuid
+        value:
+          type: object
+          additionalProperties: true
+      required:
+        - businessArtifactDefinitionId
+
+    BusinessArtifactActionCreateParams:
+      description: |
+        Params to invoke an action on a Business Artifact. The populated
+        sub-field (`startWorkflow`, `downloadable`, `startProcess`,
+        `createArtifact`) must match the type of the action identified by
+        `businessArtifactActionDefinitionCode`.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        businessArtifactActionDefinitionCode:
+          type: string
+        startWorkflow:
+          $ref: "#/components/schemas/BusinessArtifactActionCreateParamsStartWorkflow"
+        downloadable:
+          $ref: "#/components/schemas/BusinessArtifactActionCreateParamsDownloadable"
+        startProcess:
+          $ref: "#/components/schemas/BusinessArtifactActionCreateParamsStartProcess"
+        createArtifact:
+          $ref: "#/components/schemas/BusinessArtifactActionCreateParamsCreateArtifact"
+      required:
+        - businessArtifactActionDefinitionCode
+
+    BusinessArtifactActionCreateParamsStartWorkflow:
+      description: Params for invoking an action of type START_WORKFLOW.
+      type: object
+      properties:
+        input:
+          description: Input passed to the workflow. Validated against the action's input schema.
+          type: object
+          additionalProperties: true
+
+    BusinessArtifactActionCreateParamsDownloadable:
+      description: Params for invoking an action of type DOWNLOADABLE.
+      type: object
+      properties:
+        input:
+          description: Input passed to the workflow that produces the downloadable. Validated against the action's input schema.
+          type: object
+          additionalProperties: true
+
+    BusinessArtifactActionCreateParamsStartProcess:
+      description: Params for invoking an action of type START_PROCESS.
+      type: object
+      properties:
+        metadata:
+          description: Metadata applied to the process created by this action.
+          type: object
+          additionalProperties: true
+
+    BusinessArtifactActionCreateParamsCreateArtifact:
+      description: |
+        Params for invoking an action of type CREATE_BUSINESS_ARTIFACT. The `value` is
+        the (potentially user-edited) form previously obtained via the
+        `previewBusinessArtifactCreateArtifact` operation.
+      type: object
+      properties:
+        value:
+          description: Form value to be applied to the new Business Artifact.
+          type: object
+          additionalProperties: true
+
+    BusinessArtifactCreateArtifactPreviewParams:
+      description: Params identifying a CREATE_BUSINESS_ARTIFACT action to preview.
+      type: object
+      properties:
+        businessArtifactActionDefinitionCode:
+          type: string
+      required:
+        - businessArtifactActionDefinitionCode
+
+    BusinessArtifactCreateArtifactPreview:
+      description: |
+        Pre-filled value for a CREATE_BUSINESS_ARTIFACT action. Returned by the
+        preview operation; nothing is persisted on the server.
+      type: object
+      properties:
+        businessArtifactDefinitionId:
+          description: ID of the Business Artifact Definition that the action would create.
+          type: string
+          format: uuid
+        value:
+          description: Pre-filled form value computed from the action definition.
+          type: object
+          additionalProperties: true
+      required:
+        - businessArtifactDefinitionId
+
+    BusinessArtifactActionValueStatus:
+      description: Status of a Business Artifact action value.
+      type: string
+      enum:
+        - REQUESTED
+        - COMPLETED
+        - CANCELED
+        - ERROR
+
+    BusinessArtifactActionType:
+      description: Type of a Business Artifact action.
+      type: string
+      enum:
+        - START_WORKFLOW
+        - START_PROCESS
+        - DOWNLOADABLE
+        - CREATE_BUSINESS_ARTIFACT
+
     ProcessDefinitionRef:
       type: object
       properties:
@@ -2917,6 +3155,18 @@ components:
         - code
 
     BusinessArtifactDefinitionRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+      required:
+        - id
+        - code
+
+    BusinessArtifactActionDefinitionRef:
       type: object
       properties:
         id:

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1504,7 +1504,7 @@ paths:
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
-        - name: actionId
+        - name: actionValueId
           description: The Business Artifact action ID.
           in: path
           required: true

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1461,7 +1461,7 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/actions/{actionId}:
+  /business-artifacts/{id}/actions/{actionValueId}:
     get:
       summary: Get a Business Artifact action by ID
       description: Returns a Business Artifact action by its ID.
@@ -1471,7 +1471,7 @@ paths:
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
-        - name: actionId
+        - name: actionValueId
           description: The Business Artifact action ID.
           in: path
           required: true
@@ -1489,7 +1489,7 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/actions/{actionId}/~actions/cancel:
+  /business-artifacts/{id}/actions/{actionValueId}/~actions/cancel:
     post:
       summary: Cancel a Business Artifact action
       description: |

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1451,17 +1451,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifactActionValue"
+                $ref: "#/components/schemas/BusinessArtifactAction"
         "201":
           description: Business Artifact action created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifactActionValue"
+                $ref: "#/components/schemas/BusinessArtifactAction"
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/actions/{actionValueId}:
+  /business-artifacts/{id}/actions/{actionId}:
     get:
       summary: Get a Business Artifact action by ID
       description: Returns a Business Artifact action by its ID.
@@ -1471,7 +1471,7 @@ paths:
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
-        - name: actionValueId
+        - name: actionId
           description: The Business Artifact action ID.
           in: path
           required: true
@@ -1485,11 +1485,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifactActionValue"
+                $ref: "#/components/schemas/BusinessArtifactAction"
         default:
           $ref: "#/components/responses/DefaultError"
 
-  /business-artifacts/{id}/actions/{actionValueId}/~actions/cancel:
+  /business-artifacts/{id}/actions/{actionId}/~actions/cancel:
     post:
       summary: Cancel a Business Artifact action
       description: |
@@ -1504,7 +1504,7 @@ paths:
         - businessArtifact
       parameters:
         - $ref: "#/components/parameters/IdPathParam"
-        - name: actionValueId
+        - name: actionId
           description: The Business Artifact action ID.
           in: path
           required: true
@@ -1518,7 +1518,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BusinessArtifactActionValue"
+                $ref: "#/components/schemas/BusinessArtifactAction"
         default:
           $ref: "#/components/responses/DefaultError"
 
@@ -2973,7 +2973,7 @@ components:
             - tenantId
             - businessArtifactDefinitionRef
 
-    BusinessArtifactActionValue:
+    BusinessArtifactAction:
       description: |
         A Business Artifact action invocation. The populated sub-field
         (`startWorkflow`, `startProcess`, `downloadable`, `createArtifact`) is
@@ -2988,33 +2988,33 @@ components:
             type:
               $ref: "#/components/schemas/BusinessArtifactActionType"
             status:
-              $ref: "#/components/schemas/BusinessArtifactActionValueStatus"
+              $ref: "#/components/schemas/BusinessArtifactActionStatus"
             businessArtifactActionDefinitionRef:
               $ref: "#/components/schemas/BusinessArtifactActionDefinitionRef"
             startWorkflow:
-              $ref: "#/components/schemas/BusinessArtifactActionValueStartWorkflow"
+              $ref: "#/components/schemas/BusinessArtifactActionStartWorkflow"
             startProcess:
-              $ref: "#/components/schemas/BusinessArtifactActionValueStartProcess"
+              $ref: "#/components/schemas/BusinessArtifactActionStartProcess"
             downloadable:
-              $ref: "#/components/schemas/BusinessArtifactActionValueDownloadable"
+              $ref: "#/components/schemas/BusinessArtifactActionDownloadable"
             createArtifact:
-              $ref: "#/components/schemas/BusinessArtifactActionValueCreateArtifact"
+              $ref: "#/components/schemas/BusinessArtifactActionCreateArtifact"
           required:
             - id
             - type
             - status
             - businessArtifactActionDefinitionRef
 
-    BusinessArtifactActionValueStartWorkflow:
-      description: Action value details for actions of type START_WORKFLOW.
+    BusinessArtifactActionStartWorkflow:
+      description: Action details for actions of type START_WORKFLOW.
       type: object
       properties:
         input:
           $ref: "#/components/schemas/JsonValue"
 
-    BusinessArtifactActionValueStartProcess:
+    BusinessArtifactActionStartProcess:
       description: |
-        Action value details for actions of type START_PROCESS. Actions of this
+        Action details for actions of type START_PROCESS. Actions of this
         type complete synchronously, so all fields are present in the invoke
         response.
       type: object
@@ -3031,8 +3031,8 @@ components:
         - processDefinitionId
         - processId
 
-    BusinessArtifactActionValueDownloadable:
-      description: Action value details for actions of type DOWNLOADABLE.
+    BusinessArtifactActionDownloadable:
+      description: Action details for actions of type DOWNLOADABLE.
       type: object
       properties:
         input:
@@ -3044,9 +3044,9 @@ components:
           description: Whether the generated document has expired. Only present when status is COMPLETED.
           type: boolean
 
-    BusinessArtifactActionValueCreateArtifact:
+    BusinessArtifactActionCreateArtifact:
       description: |
-        Action value details for actions of type CREATE_BUSINESS_ARTIFACT.
+        Action details for actions of type CREATE_BUSINESS_ARTIFACT.
         Actions of this type complete synchronously, so the populated value and
         the created Business Artifact ID are present in the invoke response.
       type: object
@@ -3151,8 +3151,8 @@ components:
       required:
         - businessArtifactDefinitionRef
 
-    BusinessArtifactActionValueStatus:
-      description: Status of a Business Artifact action value.
+    BusinessArtifactActionStatus:
+      description: Status of a Business Artifact action.
       type: string
       enum:
         - REQUESTED

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -3006,14 +3006,13 @@ components:
     BusinessArtifactActionValueCreateArtifact:
       type: object
       properties:
-        businessArtifactDefinitionId:
-          type: string
-          format: uuid
+        businessArtifactDefinitionRef:
+          $ref: "#/components/schemas/BusinessArtifactDefinitionRef"
         value:
           type: object
           additionalProperties: true
       required:
-        - businessArtifactDefinitionId
+        - businessArtifactDefinitionRef
 
     BusinessArtifactActionCreateParams:
       description: |

--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -1489,6 +1489,39 @@ paths:
         default:
           $ref: "#/components/responses/DefaultError"
 
+  /business-artifacts/{id}/actions/{actionId}/~actions/cancel:
+    post:
+      summary: Cancel a Business Artifact action
+      description: |
+        Cancel a Business Artifact action.
+
+        Only meaningful for asynchronous actions still in `REQUESTED` state. The
+        action's status is set to `CANCELED`. If the action is already in a
+        terminal state, no transition occurs.
+      operationId: cancelBusinessArtifactAction
+      tags:
+        - apiRestExternalV20240614BusinessArtifacts
+        - businessArtifact
+      parameters:
+        - $ref: "#/components/parameters/IdPathParam"
+        - name: actionId
+          description: The Business Artifact action ID.
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          x-ms-parameter-location: method
+      responses:
+        "200":
+          description: Business Artifact action cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessArtifactActionValue"
+        default:
+          $ref: "#/components/responses/DefaultError"
+
   /business-artifacts/{id}/~actions/prepare-create-artifact:
     post:
       summary: Prepare the data for a CREATE_BUSINESS_ARTIFACT action
@@ -2944,7 +2977,7 @@ components:
       description: |
         A Business Artifact action invocation. The populated sub-field
         (`startWorkflow`, `startProcess`, `downloadable`, `createArtifact`) is
-        dictated by `businessArtifactActionDefinitionRef`.
+        dictated by `type`.
       allOf:
         - $ref: "#/components/schemas/AbstractAudited"
         - type: object
@@ -2958,8 +2991,6 @@ components:
               $ref: "#/components/schemas/BusinessArtifactActionValueStatus"
             businessArtifactActionDefinitionRef:
               $ref: "#/components/schemas/BusinessArtifactActionDefinitionRef"
-            archived:
-              type: boolean
             startWorkflow:
               $ref: "#/components/schemas/BusinessArtifactActionValueStartWorkflow"
             startProcess:
@@ -2975,18 +3006,25 @@ components:
             - businessArtifactActionDefinitionRef
 
     BusinessArtifactActionValueStartWorkflow:
+      description: Action value details for actions of type START_WORKFLOW.
       type: object
       properties:
         input:
           $ref: "#/components/schemas/JsonValue"
 
     BusinessArtifactActionValueStartProcess:
+      description: |
+        Action value details for actions of type START_PROCESS. Actions of this
+        type complete synchronously, so all fields are present in the invoke
+        response.
       type: object
       properties:
         processDefinitionId:
+          description: ID of the Process Definition that was instantiated.
           type: string
           format: uuid
         processId:
+          description: ID of the Process created by this action.
           type: string
           format: uuid
       required:
@@ -2994,21 +3032,33 @@ components:
         - processId
 
     BusinessArtifactActionValueDownloadable:
+      description: Action value details for actions of type DOWNLOADABLE.
       type: object
       properties:
         input:
           $ref: "#/components/schemas/JsonValue"
         documentUri:
+          description: URI of the generated document. Only present when status is COMPLETED.
           type: string
         documentExpired:
+          description: Whether the generated document has expired. Only present when status is COMPLETED.
           type: boolean
 
     BusinessArtifactActionValueCreateArtifact:
+      description: |
+        Action value details for actions of type CREATE_BUSINESS_ARTIFACT.
+        Actions of this type complete synchronously, so the populated value and
+        the created Business Artifact ID are present in the invoke response.
       type: object
       properties:
         businessArtifactDefinitionRef:
           $ref: "#/components/schemas/BusinessArtifactDefinitionRef"
+        businessArtifactId:
+          description: ID of the Business Artifact created by this action. Only present when status is COMPLETED.
+          type: string
+          format: uuid
         value:
+          description: Form value applied to the new Business Artifact.
           type: object
           additionalProperties: true
       required:


### PR DESCRIPTION
- Add `POST /business-artifacts/{id}/actions` (invoke) and `GET .../{actionId}` (retrieve).
- Add `POST /business-artifacts/{id}/actions/{actionId}/~actions/cancel` to abort async actions.
- Add `POST /business-artifacts/{id}/~actions/prepare-create-artifact` for stateless `CREATE_BUSINESS_ARTIFACT` form preparation.
- Model invoke params and action value as sibling fields by type (`startWorkflow.input`, `downloadable.input`, `startProcess.metadata`, `createArtifact.value`), matching the `ProcessItem` polymorphism pattern.
- Add `BusinessArtifactActionDefinitionRef` schema mirroring `BusinessArtifactDefinitionRef`.
- Remove unused `uploadBusinessArtifactUserActionDocument` endpoint.

Refs #85