### PR TITLE
feat(processes): allow entity initialization on process create and START_PROCESS actions

### DIFF
--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -2561,6 +2561,8 @@ components:
           type: string
         metadata:
           $ref: "#/components/schemas/JsonValue"
+        entity:
+          $ref: "#/components/schemas/JsonValue"
         initiatorId:
           type: string
           format: uuid
@@ -3112,6 +3114,14 @@ components:
       properties:
         metadata:
           description: Metadata applied to the process created by this action.
+          type: object
+          additionalProperties: true
+        entity:
+          description: |
+            Entity data applied to the process created by this action. Validated
+            against the process definition entity schema; validation errors are
+            recorded on the process entity value. Ignored if empty or if the
+            process definition has no entity structure.
           type: object
           additionalProperties: true
 


### PR DESCRIPTION
Add an optional `entity` field to let clients initialize a process's entity data at creation time, instead of requiring a separate update call after the process is created.

- `ProcessCreateParams`: add optional `entity` (`JsonValue`) so callers can set the initial entity data when creating a process via the Process Create API.
- `BusinessArtifactActionCreateParamsStartProcess`: add optional `entity` (free-form object) so the `START_PROCESS` business artifact action can initialize entity data on the process it creates. Validated against the process definition's entity schema; validation errors are recorded on the process entity value. Ignored if empty or if the process definition has no entity structure.

Close #89