### PR TITLE
feat(openapi): add relatedProcessId field to process creation schema

### DIFF
--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -2569,6 +2569,12 @@ components:
         initiatorEmail:
           type: string
           format: email
+        relatedProcessId:
+          description: |
+            Optional id of another process to which the created process is
+            related. Surfaced on read as `Process.processRelated.outcoming`.
+          type: string
+          format: uuid
       anyOf:
         - required:
             - processDefinitionId


### PR DESCRIPTION
## Summary

Adds an optional `relatedProcessId` field to allow linking a newly created process to another existing process at creation time.

## Key changes

- Add optional `relatedProcessId` (UUID) field to `ProcessCreateParams` in the OpenAPI spec.
- Document that the relationship is surfaced on read via `Process.processRelated.outcoming` (and `incoming` on the related process).

## Testing

Spec-only change; no runtime testing applicable.

Closes #91
