### PR TITLE
feat(processes): add metadata query parameter to GET /processes

### DIFF
--- a/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+++ b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
@@ -390,6 +390,25 @@ paths:
         - $ref: "#/components/parameters/TenantIdQueryParam"
         - $ref: "#/components/parameters/ProcessDefinitionIdQueryParam"
         - $ref: "#/components/parameters/ProcessDefinitionCodeQueryParam"
+        - name: metadata
+          description: |
+            Filter by process metadata field values. Each value is an expression with the format
+            `fieldCode operation value1 value2...` (space-separated).
+
+            Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+
+            Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              pattern: '^\S+ (eq|le|ge|between|contains|in) \S+( \S+)*$'
+          example:
+            - "invoiceNumber eq INV-001"
+            - "amount ge 100"
+          style: form
+          explode: true
       responses:
         "200":
           description: Processes found paginated


### PR DESCRIPTION
## Summary

Adds a `metadata` query parameter to the `GET /processes` operation, mirroring the existing `value`
filter on `GET /business-artifacts`, so processes can be filtered by their metadata field values.

## Key changes

- New `metadata` array query parameter on `findProcesses`, using the same
  `fieldCode operation value1 value2...` expression syntax and pattern validation as Business Artifacts'
  `value` parameter (`eq`, `le`, `ge`, `between`, `contains`, `in`).
- Documents that filtering by metadata requires specifying exactly one `processDefinitionId` or
  `processDefinitionCode`.

Closes #93
